### PR TITLE
Update number API to match Ghost's new int64/float64 representation

### DIFF
--- a/engine/font.go
+++ b/engine/font.go
@@ -57,8 +57,8 @@ func (font *Font) Method(method string, args []object.Object) (object.Object, bo
 
 func (font *Font) print(args []object.Object) {
 	text := args[0].String()
-	x := int32(args[1].(*object.Number).Value.IntPart())
-	y := int32(args[2].(*object.Number).Value.IntPart())
+	x := int32(args[1].(*object.Number).Int64())
+	y := int32(args[2].(*object.Number).Int64())
 
 	x, y = Lumen.ApplyOffset(x, y)
 

--- a/engine/image.go
+++ b/engine/image.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"ghostlang.org/x/ghost/object"
-	"github.com/shopspring/decimal"
 	"github.com/veandco/go-sdl2/sdl"
 )
 
@@ -50,8 +49,8 @@ func (image *Image) Method(method string, args []object.Object) (object.Object, 
 // Object methods
 
 func (image *Image) draw(args []object.Object) {
-	x := int32(args[0].(*object.Number).Value.IntPart())
-	y := int32(args[1].(*object.Number).Value.IntPart())
+	x := int32(args[0].(*object.Number).Int64())
+	y := int32(args[1].(*object.Number).Int64())
 
 	x, y = Lumen.ApplyOffset(x, y)
 
@@ -80,9 +79,9 @@ func (image *Image) draw(args []object.Object) {
 
 // clip applies an X and Y offset to the image.
 func (image *Image) clip(args []object.Object) object.Object {
-	x := int32(args[0].(*object.Number).Value.IntPart())
-	y := int32(args[1].(*object.Number).Value.IntPart())
-	size := int32(args[2].(*object.Number).Value.IntPart())
+	x := int32(args[0].(*object.Number).Int64())
+	y := int32(args[1].(*object.Number).Int64())
+	size := int32(args[2].(*object.Number).Int64())
 
 	image.XOffset = x
 	image.YOffset = y
@@ -93,10 +92,10 @@ func (image *Image) clip(args []object.Object) object.Object {
 
 // getWidth returns the width of the image.
 func (image *Image) getWidth(args []object.Object) object.Object {
-	return &object.Number{Value: decimal.NewFromInt32(image.Width)}
+	return object.NewInt(int64(image.Width))
 }
 
 // getHeight returns the height of the image.
 func (image *Image) getHeight(args []object.Object) object.Object {
-	return &object.Number{Value: decimal.NewFromInt32(image.Height)}
+	return object.NewInt(int64(image.Height))
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,4 @@ require (
 	github.com/veandco/go-sdl2 v0.4.35
 )
 
-require github.com/shopspring/decimal v1.3.1 // indirect
-
-replace ghostlang.org/x/ghost => ../ghost
+replace ghostlang.org/x/ghost => /Users/kai/.claude-worktrees/ghost/nervous-johnson

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-ghostlang.org/x/ghost v0.18.0 h1:fK9vt4kgrVlTABqqe7pZqvLyr47GtAwHZkGNl+otoYk=
-ghostlang.org/x/ghost v0.18.0/go.mod h1:ZHkaQCPgPsvceD0nZJv4b1C0UiErOUypWqAV1GuRiMk=
-github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
-github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/veandco/go-sdl2 v0.4.35 h1:NohzsfageDWGtCd9nf7Pc3sokMK/MOK+UA2QMJARWzQ=
 github.com/veandco/go-sdl2 v0.4.35/go.mod h1:OROqMhHD43nT4/i9crJukyVecjPNYYuCofep6SNiAjY=

--- a/modules/canvas.go
+++ b/modules/canvas.go
@@ -38,10 +38,10 @@ func canvasRectangleMethod(scope *object.Scope, tok token.Token, args ...object.
 		return object.NewError("wrong number of arguments. got=%d, want=4", len(args))
 	}
 
-	x := int32(args[0].(*object.Number).Value.IntPart())
-	y := int32(args[1].(*object.Number).Value.IntPart())
-	w := int32(args[2].(*object.Number).Value.IntPart())
-	h := int32(args[3].(*object.Number).Value.IntPart())
+	x := int32(args[0].(*object.Number).Int64())
+	y := int32(args[1].(*object.Number).Int64())
+	w := int32(args[2].(*object.Number).Int64())
+	h := int32(args[3].(*object.Number).Int64())
 
 	rectangle := sdl.Rect{X: x, Y: y, W: w, H: h}
 
@@ -55,10 +55,10 @@ func canvasFilledRectangleMethod(scope *object.Scope, tok token.Token, args ...o
 		return object.NewError("wrong number of arguments. got=%d, want=4", len(args))
 	}
 
-	x := int32(args[0].(*object.Number).Value.IntPart())
-	y := int32(args[1].(*object.Number).Value.IntPart())
-	w := int32(args[2].(*object.Number).Value.IntPart())
-	h := int32(args[3].(*object.Number).Value.IntPart())
+	x := int32(args[0].(*object.Number).Int64())
+	y := int32(args[1].(*object.Number).Int64())
+	w := int32(args[2].(*object.Number).Int64())
+	h := int32(args[3].(*object.Number).Int64())
 
 	x, y = engine.Lumen.ApplyOffset(x, y)
 
@@ -74,9 +74,9 @@ func canvasCircleMethod(scope *object.Scope, tok token.Token, args ...object.Obj
 		return object.NewError("wrong number of arguments. got=%d, want=3", len(args))
 	}
 
-	x := int32(args[0].(*object.Number).Value.IntPart())
-	y := int32(args[1].(*object.Number).Value.IntPart())
-	r := int32(args[2].(*object.Number).Value.IntPart())
+	x := int32(args[0].(*object.Number).Int64())
+	y := int32(args[1].(*object.Number).Int64())
+	r := int32(args[2].(*object.Number).Int64())
 
 	d := int32(math.Pi - float64(2*r))
 
@@ -113,9 +113,9 @@ func canvasFilledCircleMethod(scope *object.Scope, tok token.Token, args ...obje
 		return object.NewError("wrong number of arguments. got=%d, want=3", len(args))
 	}
 
-	x := int32(args[0].(*object.Number).Value.IntPart())
-	y := int32(args[1].(*object.Number).Value.IntPart())
-	r := int32(args[2].(*object.Number).Value.IntPart())
+	x := int32(args[0].(*object.Number).Int64())
+	y := int32(args[1].(*object.Number).Int64())
+	r := int32(args[2].(*object.Number).Int64())
 
 	d := int32(math.Pi - float64(2*r))
 
@@ -148,10 +148,10 @@ func canvasLineMethod(scope *object.Scope, tok token.Token, args ...object.Objec
 		return object.NewError("wrong number of arguments. got=%d, want=4", len(args))
 	}
 
-	x1 := int32(args[0].(*object.Number).Value.IntPart())
-	y1 := int32(args[1].(*object.Number).Value.IntPart())
-	x2 := int32(args[2].(*object.Number).Value.IntPart())
-	y2 := int32(args[3].(*object.Number).Value.IntPart())
+	x1 := int32(args[0].(*object.Number).Int64())
+	y1 := int32(args[1].(*object.Number).Int64())
+	x2 := int32(args[2].(*object.Number).Int64())
+	y2 := int32(args[3].(*object.Number).Int64())
 
 	x1, y1 = engine.Lumen.ApplyOffset(x1, y1)
 	x2, y2 = engine.Lumen.ApplyOffset(x2, y2)
@@ -166,8 +166,8 @@ func canvasPointMethod(scope *object.Scope, tok token.Token, args ...object.Obje
 		return object.NewError("wrong number of arguments. got=%d, want=2", len(args))
 	}
 
-	x := int32(args[0].(*object.Number).Value.IntPart())
-	y := int32(args[1].(*object.Number).Value.IntPart())
+	x := int32(args[0].(*object.Number).Int64())
+	y := int32(args[1].(*object.Number).Int64())
 
 	x, y = engine.Lumen.ApplyOffset(x, y)
 
@@ -237,11 +237,11 @@ func canvasScaleMethod(scope *object.Scope, tok token.Token, args ...object.Obje
 	var x, y float32
 
 	if len(args) == 2 {
-		x, _ = args[0].(*object.Number).Value.BigFloat().Float32()
-		y, _ = args[1].(*object.Number).Value.BigFloat().Float32()
+		x = float32(args[0].(*object.Number).Float64())
+		y = float32(args[1].(*object.Number).Float64())
 	} else {
-		x, _ = args[0].(*object.Number).Value.BigFloat().Float32()
-		y, _ = args[0].(*object.Number).Value.BigFloat().Float32()
+		x = float32(args[0].(*object.Number).Float64())
+		y = float32(args[0].(*object.Number).Float64())
 	}
 
 	engine.Lumen.Renderer.SetScale(x, y)
@@ -257,11 +257,11 @@ func canvasTranslateMethod(scope *object.Scope, tok token.Token, args ...object.
 	var x, y float32
 
 	if len(args) == 2 {
-		x, _ = args[0].(*object.Number).Value.BigFloat().Float32()
-		y, _ = args[1].(*object.Number).Value.BigFloat().Float32()
+		x = float32(args[0].(*object.Number).Float64())
+		y = float32(args[1].(*object.Number).Float64())
 	} else {
-		x, _ = args[0].(*object.Number).Value.BigFloat().Float32()
-		y, _ = args[0].(*object.Number).Value.BigFloat().Float32()
+		x = float32(args[0].(*object.Number).Float64())
+		y = float32(args[0].(*object.Number).Float64())
 	}
 
 	engine.Lumen.OffsetX = int32(x)

--- a/modules/color.go
+++ b/modules/color.go
@@ -28,13 +28,13 @@ func colorRgbMethod(scope *object.Scope, tok token.Token, args ...object.Object)
 		return object.NewError("wrong number of arguments. got=%d, want=3", len(args))
 	}
 
-	red := uint8(args[0].(*object.Number).Value.IntPart())
-	green := uint8(args[1].(*object.Number).Value.IntPart())
-	blue := uint8(args[2].(*object.Number).Value.IntPart())
+	red := uint8(args[0].(*object.Number).Int64())
+	green := uint8(args[1].(*object.Number).Int64())
+	blue := uint8(args[2].(*object.Number).Int64())
 	alpha := uint8(255)
 
 	if len(args) == 4 {
-		alpha = uint8(args[3].(*object.Number).Value.IntPart())
+		alpha = uint8(args[3].(*object.Number).Int64())
 	}
 
 	color := new(engine.Color)

--- a/modules/font.go
+++ b/modules/font.go
@@ -23,7 +23,7 @@ func fontLoadMethod(scope *object.Scope, tok token.Token, args ...object.Object)
 		return object.NewError("wrong number of arguments. got=%d, want=1", len(args))
 	}
 
-	font := engine.NewFont(args[0].String(), int(args[1].(*object.Number).Value.IntPart()))
+	font := engine.NewFont(args[0].String(), int(args[1].(*object.Number).Int64()))
 
 	return font
 }

--- a/modules/mouse.go
+++ b/modules/mouse.go
@@ -5,7 +5,6 @@ import (
 	"ghostlang.org/x/ghost/object"
 	"ghostlang.org/x/ghost/token"
 	"ghostlang.org/x/lumen/engine"
-	"github.com/shopspring/decimal"
 	"github.com/veandco/go-sdl2/sdl"
 )
 
@@ -119,11 +118,11 @@ func mouseWasButtonReleasedMethod(scope *object.Scope, tok token.Token, args ...
 func mouseXProperty(scope *object.Scope, tok token.Token) object.Object {
 	x, _, _ := sdl.GetMouseState()
 
-	return &object.Number{Value: decimal.NewFromInt(int64(x))}
+	return object.NewInt(int64(x))
 }
 
 func mouseYProperty(scope *object.Scope, tok token.Token) object.Object {
 	_, y, _ := sdl.GetMouseState()
 
-	return &object.Number{Value: decimal.NewFromInt(int64(y))}
+	return object.NewInt(int64(y))
 }

--- a/modules/window.go
+++ b/modules/window.go
@@ -5,7 +5,6 @@ import (
 	"ghostlang.org/x/ghost/object"
 	"ghostlang.org/x/ghost/token"
 	"ghostlang.org/x/lumen/engine"
-	"github.com/shopspring/decimal"
 )
 
 var WindowMethods = map[string]*object.LibraryFunction{}
@@ -39,17 +38,17 @@ func windowTitleMethod(scope *object.Scope, tok token.Token, args ...object.Obje
 }
 
 func windowFpsProperty(scope *object.Scope, tok token.Token) object.Object {
-	return &object.Number{Value: decimal.NewFromInt(int64(engine.Lumen.CurrentFps))}
+	return object.NewInt(int64(engine.Lumen.CurrentFps))
 }
 
 func windowWidthProperty(scope *object.Scope, tok token.Token) object.Object {
 	w, _ := engine.Lumen.Window.GetSize()
 
-	return &object.Number{Value: decimal.NewFromInt(int64(w))}
+	return object.NewInt(int64(w))
 }
 
 func windowHeightProperty(scope *object.Scope, tok token.Token) object.Object {
 	_, h := engine.Lumen.Window.GetSize()
 
-	return &object.Number{Value: decimal.NewFromInt(int64(h))}
+	return object.NewInt(int64(h))
 }


### PR DESCRIPTION
## Summary

- Updates all Lumen integration points to use Ghost's new `Number` API
- `.Value.IntPart()` → `.Int64()`
- `decimal.NewFromInt()`/`decimal.NewFromInt32()` → `object.NewInt()`
- `.Value.BigFloat().Float32()` → `float32(n.Float64())`
- Removes the `shopspring/decimal` indirect dependency

## Motivation

Companion PR to ghost-language/ghost. Ghost's number system has been rewritten to use a dual `int64`/`float64` representation, eliminating the `decimal.Decimal` arbitrary-precision overhead that was the primary performance bottleneck in hot loops like tilemap rendering.

## Files changed

- `engine/image.go`, `engine/font.go`
- `modules/canvas.go`, `modules/color.go`, `modules/font.go`, `modules/mouse.go`, `modules/window.go`
- `go.mod`, `go.sum`

## Test plan

- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)